### PR TITLE
Delete .npmrc file after each stage

### DIFF
--- a/vars/npm.groovy
+++ b/vars/npm.groovy
@@ -8,6 +8,7 @@ def withAuth(String registry = "registry.npmjs.org", String secretPath = "secret
   wrap([$class: 'VaultBuildWrapper', vaultSecrets: secrets]) {
     sh "echo \"//${registry}/:_authToken=\\\${NPM_TOKEN}\" > ~/.npmrc"
     body()
+    sh "rm ~/.npmrc"
   }
 }
 


### PR DESCRIPTION
This should ensure that we only need to `withAuth` on
steps which need to call the npm registry authenticated.

See https://jenkins-k8s.actano.de/job/actano/job/signup-login-webclient/job/master/27/console for a working example and https://github.com/actano/signup-login-webclient/blob/6c8a4ac4d2865780eacd6b23f87683bb5ff6652b/Jenkinsfile-k8s for its Jenkinsfile